### PR TITLE
Master coloring mixin for all charts

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -296,3 +296,6 @@ a {
 
 // New Charts module
 @import 'new-charts/tc-charts';
+
+// Will use all mixins defined before
+@import 'new-charts/color-elements';

--- a/new-charts/color-elements.scss
+++ b/new-charts/color-elements.scss
@@ -1,0 +1,14 @@
+@mixin colorChartsElementsByName($name, $color) {
+  // Legacy
+  [data-subgroup="#{$name}"],
+  [data-label="#{$name}"],
+  [data-serie="#{$name}"] {
+    @include colorSVGElement($color);
+  }
+
+  // tc-barchart
+  @include colorTcBarchartBarByName($name, $color);
+
+  // tc-legend
+  @include colorTcLegendCategoryByName($name, $color);
+}

--- a/new-charts/tc-barchart.scss
+++ b/new-charts/tc-barchart.scss
@@ -1,15 +1,26 @@
 $tc-bar-chart-bar-color--selected: $emphasis-color;
 
-.bar-chart__chart-container .bar-chart__bar-group {
-  @each $color in $chartColors {
-    $i: index($chartColors, $color) - 1;
-    &[data-serie-index="#{$i}"] .vertical-bar__bar {
-      fill: $color;
-    }
+@mixin colorTcBarchartBarByAttr($attr, $value, $color) {
+  .bar-chart__chart-container .bar-chart__bar-group[#{$attr}="#{$value}"] .vertical-bar__bar {
+    fill: $color;
   }
 }
 
-.bar-chart__chart-container .x-groups--selected .bar-group .vertical-bar__bar {
+@mixin colorTcBarchartBarById($id, $color) {
+  @include colorTcBarchartBarByAttr(data-serie-index, $id, $color);
+}
+
+@mixin colorTcBarchartBarByName($name, $color) {
+  @include colorTcBarchartBarByAttr(data-serie, $name, $color);
+}
+
+@each $color in $chartColors {
+  $i: index($chartColors, $color) - 1;
+  @include colorTcBarchartBarById($i, $color);
+}
+
+
+.bar-chart__chart-container .x-groups--selected .bar-chart__bar-group .vertical-bar__bar {
   fill: $tc-bar-chart-bar-color--selected;
 
   &:hover {

--- a/new-charts/tc-legend/tc-legend-ordinal.scss
+++ b/new-charts/tc-legend/tc-legend-ordinal.scss
@@ -1,6 +1,18 @@
-@each $color in $chartColors {
-  $i: index($chartColors, $color) - 1;
-  .tc-legend-ordinal__category[data-category-index="#{$i}"] .tc-legend-ordinal__category-color {
+@mixin colorTcLegendCategoryByAttr($attr, $value, $color) {
+  .tc-legend-ordinal__category[#{$attr}="#{$value}"] .tc-legend-ordinal__category-color {
     background-color: $color;
   }
+}
+
+@mixin colorTcLegendCategoryById($id, $color) {
+  @include colorTcLegendCategoryByAttr(data-category-index, $id, $color);
+}
+
+@mixin colorTcLegendCategoryByName($name, $color) {
+  @include colorTcLegendCategoryByAttr(data-category, $name, $color);
+}
+
+@each $color in $chartColors {
+  $i: index($chartColors, $color) - 1;
+  @include colorTcLegendCategoryById($i, $color);
 }


### PR DESCRIPTION
`colorChartsElementsByName` allow to color all charts elements using the mixins they provide in their scss module.
