### PR TITLE
fix :: color of tcslider in settings panel

### DIFF
--- a/settings-panel.scss
+++ b/settings-panel.scss
@@ -1,4 +1,20 @@
 settings-panel {
+  filter, requester {
+    tc-slider {
+      .tc-slider {
+        border-color: white;
+        .rz-bubble {
+          color: white;
+        }
+        .rz-bar, .rz-bar.rz-selection {
+          background: white;
+        }
+      }
+    }
+
+
+  }
+
   background: $main-color;
   .settings-button-container {
     >.settings-button.with-notification::after {


### PR DESCRIPTION
The color of the tcslider was $maincolor, so in the settings panel where colors are reversed, it became invisible

before
<img width="352" alt="screen shot 2018-04-03 at 16 34 54" src="https://user-images.githubusercontent.com/7557261/38255818-15e1ed06-375d-11e8-89fa-58079f6551b6.png">
after
<img width="353" alt="screen shot 2018-04-03 at 16 30 02" src="https://user-images.githubusercontent.com/7557261/38255833-2125dbfa-375d-11e8-8b59-2d9055a38915.png">

Related width fix : https://github.com/ToucanToco/tucana/pull/3144
