### PR TITLE
Feature :: Update mixin colorChartsElementsByName

### DIFF
--- a/new-charts/color-elements.scss
+++ b/new-charts/color-elements.scss
@@ -17,4 +17,16 @@
 
   // tc-lines
   @include colorTcLinesSerieByName($name, $color);
+
+  // tc-bubblechart
+  @include colorBubbleChartByName($name, $color);
+
+  // tc-waterfall
+  @include colorWaterfallBarAndValuesByName($name, $color);
+
+  // tc-radarchart
+  @include colorTcRadarchartShapeByName($name, $color);
+
+  // tc-stackedbarchart
+  @include colorStackedBarsByName($name, $color);
 }

--- a/new-charts/tc-barchart.scss
+++ b/new-charts/tc-barchart.scss
@@ -12,6 +12,7 @@ $tc-bar-chart-bar-color--selected: $emphasis-color;
 
 @mixin colorTcBarchartBarByName($name, $color) {
   @include colorTcBarchartBarByAttr(data-serie, $name, $color);
+  @include colorTcBarchartBarByAttr(data-style, $name, $color);
 }
 
 @each $color in $chartColors {

--- a/new-charts/tc-bubblechart.scss
+++ b/new-charts/tc-bubblechart.scss
@@ -1,3 +1,23 @@
+@mixin colorBubbleChartByAttr($attr, $value, $color) {
+  .bubblechart__bubbles__main[#{$attr}="#{$value}"],
+  .circle-main[#{$attr}="#{$value}"] {
+    fill: $color;
+    stroke: $color;
+  }
+  &.selected {
+    .circle-main{
+      fill: $emphasis-color!important;
+      stroke: $emphasis-color!important;
+    }
+  }
+}
+
+@mixin colorBubbleChartByName($name, $color) {
+  @include colorBubbleChartByAttr(data-serie, $name, $color);
+  @include colorBubbleChartByAttr(data-group, $name, $color);
+  @include colorBubbleChartByAttr(data-style, $name, $color);
+}
+
 .bubblechart__color-gradient__tick {
   fill: $grey;
 }

--- a/new-charts/tc-horizontal-barchart.scss
+++ b/new-charts/tc-horizontal-barchart.scss
@@ -1,7 +1,8 @@
 $tc-bar-chart-bar-color--selected: $emphasis-color;
 
 @mixin colorTcHorizontalBarchartBarByAttr($attr, $value, $color) {
-  .horizontal-bar-chart__bar-group .horizontal-bar__bar[#{$attr}="#{$value}"] {
+  .horizontal-bar-chart__bar-group .horizontal-bar__bar[#{$attr}="#{$value}"],
+  .horizontal-bar-chart__y-label[#{$attr}="#{$value}"] .horizontal-bar__bar {
     fill: $color;
   }
 }
@@ -12,6 +13,8 @@ $tc-bar-chart-bar-color--selected: $emphasis-color;
 
 @mixin colorTcHorizontalBarchartBarByName($name, $color) {
   @include colorTcHorizontalBarchartBarByAttr(data-serie, $name, $color);
+  @include colorTcHorizontalBarchartBarByAttr(data-label, $name, $color);
+  @include colorTcHorizontalBarchartBarByAttr(data-style, $name, $color);
 }
 
 @each $color in $chartColors {

--- a/new-charts/tc-lines.scss
+++ b/new-charts/tc-lines.scss
@@ -16,6 +16,7 @@
 
 @mixin colorTcLinesSerieByName($name, $color) {
   @include colorTcLinesSerieByAttr(data-serie, $name, $color);
+  @include colorTcLinesSerieByAttr(data-style, $name, $color);
 }
 
 @each $color in $chartColors {

--- a/new-charts/tc-radarchart.scss
+++ b/new-charts/tc-radarchart.scss
@@ -20,10 +20,10 @@
   .radar-shape[#{$attr}="#{$value}"] {
     stroke: $color;
   }
-    .fill-shape[#{$attr}="#{$value}"] {
-        fill: $color;
-        stroke: none;
-    }
+  .fill-shape[#{$attr}="#{$value}"] {
+    fill: $color;
+    stroke: none;
+  }
 }
 
 @mixin colorTcRadarchartShapeById($id, $color) {
@@ -32,6 +32,7 @@
 
 @mixin colorTcRadarchartShapeByName($name, $color) {
   @include colorTcRadarchartShapeByAttr(data-serie, $name, $color);
+  @include colorTcRadarchartShapeByAttr(data-style, $name, $color);
 }
 
 @each $color in $chartColors {
@@ -50,7 +51,7 @@
   @include colorTcRadarchartMetricsLabelsByAttr(data-serie-index, $id, $color);
 }
 
-@mixin colorTcRadarchartShapeByName($name, $color) {
+@mixin colorTcRadarchartMetricsLabelByName($name, $color) {
   @include colorTcRadarchartMetricsLabelsByAttr(data-serie, $name, $color);
 }
 

--- a/new-charts/tc-stackedbarchart.scss
+++ b/new-charts/tc-stackedbarchart.scss
@@ -3,16 +3,20 @@
       background-color: $color;
     }
   }
-  
+
   @mixin colorStackedBarsById($id, $color) {
     @include colorStackedBarsByAttr(data-serie-index, $id, $color);
   }
-  
+
+  @mixin colorStackedBarsByName($id, $color) {
+    @include colorStackedBarsByAttr(data-serie, $id, $color);
+  }
+
   @each $color in $chartColors {
     $i: index($chartColors, $color) - 1;
     @include colorStackedBarsById($i, $color);
   }
-  
+
   @each $sentiment, $color in $sentiment-colors {
     .stackedbarchart-group[data-sentiment="#{$sentiment}"], .variation-clue[data-sentiment="#{$sentiment}"]{
       background-color: $color;

--- a/new-charts/tc-waterfallchart.scss
+++ b/new-charts/tc-waterfallchart.scss
@@ -16,6 +16,18 @@ $tc-waterfall-boundaries-color: $waterfallInitialColor;
 $tc-waterfall-positive-color: $waterfallPositiveColor;
 $tc-waterfall-negative-color: $waterfallNegativeColor;
 
+@mixin colorWaterfallBarAndValuesByAttr($attr, $value, $color) {
+  .waterfall-chart__bar-group[#{$attr}="#{$value}"] .vertical-bar__bar,
+  .waterfall-chart__bar-group[#{$attr}="#{$value}"] .vertical-bar__bar-value,
+  .waterfall-chart__bar-group[#{$attr}="#{$value}"] .vertical-bar__bar-variation {
+    fill: $color;
+  }
+}
+
+@mixin colorWaterfallBarAndValuesByName($name, $color) {
+  @include colorWaterfallBarAndValuesByAttr(data-label, $name, $color);
+}
+
 @mixin colorWaterfallBarAndValues($color) {
   .vertical-bar__bar-value,
   .vertical-bar__bar-variation,

--- a/variables.scss
+++ b/variables.scss
@@ -917,7 +917,7 @@ $slide-height: $viewportHeight - $headerHeight;
 }
 
 @mixin colorSVGElement($color) {
-  &.bar, &.arc, &.area, &.legend-rect, &.node, &.node-part, &.target, .text-serie, &.circle {
+  &.bar, &.arc, &.area, &.legend-rect, &.node, &.node-part, &.target, .text-serie, &.circle, &.circle-main {
     fill: $color;
   }
 


### PR DESCRIPTION
Before: mixin colorChartsElementsByName worked only on 4 charts

Now: it works on every charts with label, serie or group.

### Usage: 

`@include colorChartsElementsByName($name, $color);`

ex:
`@include colorChartsElementsByName("Berlin", #ff00e5!important);`

==> This code will color in rose all the bar/lines/circles/zones on every charts in the SmallApp with the label "Berlin"

### Screenshots

<img width="1013" alt="capture d ecran 2018-05-24 a 20 18 20" src="https://user-images.githubusercontent.com/18734475/40553651-a6aba520-6043-11e8-8e88-384d7e1cb501.png">
<img width="1012" alt="capture d ecran 2018-05-24 a 20 18 59" src="https://user-images.githubusercontent.com/18734475/40553652-a6d0fe38-6043-11e8-8b46-91910892646d.png">
<img width="1012" alt="capture d ecran 2018-05-24 a 20 19 16" src="https://user-images.githubusercontent.com/18734475/40553654-a704ff8a-6043-11e8-9254-e13e80a5354e.png">
<img width="1011" alt="capture d ecran 2018-05-24 a 20 19 31" src="https://user-images.githubusercontent.com/18734475/40553655-a72e11cc-6043-11e8-8fc0-5b6dc7d4969b.png">
<img width="1012" alt="capture d ecran 2018-05-24 a 20 19 59" src="https://user-images.githubusercontent.com/18734475/40553656-a74af292-6043-11e8-88a3-d6e33964bd79.png">
<img width="907" alt="capture d ecran 2018-05-24 a 20 30 10" src="https://user-images.githubusercontent.com/18734475/40553657-a76eb7f4-6043-11e8-8011-64f85961c4f7.png">
<img width="1011" alt="capture d ecran 2018-05-24 a 20 31 16" src="https://user-images.githubusercontent.com/18734475/40553658-a799743a-6043-11e8-9399-37c160801a6e.png">
<img width="1013" alt="capture d ecran 2018-05-24 a 20 31 34" src="https://user-images.githubusercontent.com/18734475/40553660-a7eb1cae-6043-11e8-81ce-cd57e35bd900.png">
<img width="765" alt="capture d ecran 2018-05-24 a 20 31 55" src="https://user-images.githubusercontent.com/18734475/40553661-a8473764-6043-11e8-90e8-6eecf66ba7f7.png">
<img width="1012" alt="capture d ecran 2018-05-24 a 20 32 07" src="https://user-images.githubusercontent.com/18734475/40553662-a8675602-6043-11e8-819a-fd79521ae6f4.png">
<img width="1011" alt="capture d ecran 2018-05-24 a 20 33 08" src="https://user-images.githubusercontent.com/18734475/40553665-a8c79f08-6043-11e8-9122-293364682134.png">
<img width="761" alt="capture d ecran 2018-05-24 a 20 33 26" src="https://user-images.githubusercontent.com/18734475/40553666-a8f1e498-6043-11e8-8930-d6814a32f48c.png">
<img width="1012" alt="capture d ecran 2018-05-24 a 20 33 51" src="https://user-images.githubusercontent.com/18734475/40553667-a9121ff6-6043-11e8-8f8d-df4b1f2357b1.png">
<img width="1012" alt="capture d ecran 2018-05-24 a 20 34 58" src="https://user-images.githubusercontent.com/18734475/40553668-a96de3f4-6043-11e8-9c9b-ed6f40763715.png">
