### PR TITLE
Move tc-details colors to camouflage 

### DIFF
--- a/new-charts/tc-details.scss
+++ b/new-charts/tc-details.scss
@@ -17,18 +17,3 @@
     border-right-color: $text-color;
   }
 }
-
-@mixin colorLinesLegendByAttr($attr, $value, $color) {
-  .metric__line__rect[#{$attr}="#{$value}"] {
-    background-color: $color !important;
-  }
-}
-
-@mixin colorLinesLegendById($id, $color) {
-  @include colorLinesLegendByAttr(data-serie-index, $id, $color);
-}
-
-@each $color in $chartColors {
-  $i: index($chartColors, $color) - 1;
-  @include colorLinesLegendById($i, $color);
-}


### PR DESCRIPTION
Some TcDetails colors were to be moved in camouflage... here we go!

See https://github.com/ToucanToco/camouflage/pull/157
(change naming of the branch)