### PR TITLE
Fix :: sentiment color grid view

### DIFF
--- a/sentiment.scss
+++ b/sentiment.scss
@@ -1,4 +1,4 @@
-.tc-story__chart,
+.tc-story__chart, .grid-view-container,
 chart {
   @each $name, $color in $sentimentColors {
     [data-sentiment="#{$name}"] {


### PR DESCRIPTION
Fix sentiment colors on color grid view charts

Before
![capture d ecran 2019-01-22 a 17 52 17](https://user-images.githubusercontent.com/15606814/51551401-b2696c00-1e6e-11e9-9e3d-463dc79f076a.png)


After
<img width="1220" alt="capture d ecran 2019-01-22 a 17 47 45" src="https://user-images.githubusercontent.com/15606814/51551601-0ecc8b80-1e6f-11e9-9e01-5fbcc4329bc1.png">
