### PR TITLE
Fix :: Reverse bullet chart bar and target colors

### DIFF
--- a/dashboard-report.scss
+++ b/dashboard-report.scss
@@ -84,10 +84,10 @@
         .widget-type-leaderboard {
           .widget-chart-container {
             .bar:not(.sentiment-zones) {
-                fill: nth($chartColors,2);
+                fill: nth($chartColors,1);
               }
             .target:not(.sentiment-zones) {
-                fill: nth($chartColors,1);
+                fill: nth($chartColors,3);
               }
           }
           .horizontal-barchart-subgroup.horizontal-barchart-subgroup--highlighted .bar-label {

--- a/new-charts/graphical-elements/bullet.scss
+++ b/new-charts/graphical-elements/bullet.scss
@@ -1,3 +1,3 @@
 .tc-bullet{
-  fill: nth($chartColors, 1);
+  fill: nth($chartColors, 3);
 }

--- a/new-charts/graphical-elements/horizontal-bar-with-bullet.scss
+++ b/new-charts/graphical-elements/horizontal-bar-with-bullet.scss
@@ -1,5 +1,5 @@
 .tc-horizontal-bar-with-bullet__bar{
-  fill: nth($chartColors, 3);
+  fill: nth($chartColors, 1);
 }
 
 .tc-horizontal-bar-with-bullet__comparison{


### PR DESCRIPTION
Tucana related PR => https://github.com/ToucanToco/tucana/pull/4429

Before: 
<img width="797" alt="Capture d’écran 2019-03-13 à 12 45 27" src="https://user-images.githubusercontent.com/18734475/54276931-cab45800-458e-11e9-960f-59a80832d701.png">

After: 
<img width="799" alt="Capture d’écran 2019-03-13 à 12 44 30" src="https://user-images.githubusercontent.com/18734475/54276942-d30c9300-458e-11e9-85a5-316730fdd793.png">
