### PR TITLE
Fix :: export PDF should display the background image correctly

### DIFF
--- a/print.scss
+++ b/print.scss
@@ -1,23 +1,5 @@
 .document-rendering--small-app-home {
-  body,
-  ui-view,
-  .main-small-app-wrapper,
-  .small-app-workspace,
-  small-app,
-  .screen-container,
-  .screen-container > .main-space-wrapper,
-  .report-homes-wrapper,
-  report-home,
-  .execsum,
-  .home-report-wrapper,
-  .small-app-home,
-  .small-app-workspace small-app,
-  .screen-container,
-  .small-app-home__tiles,
-  .small-app-home__tiles .category,
-  .small-app-home__content,
-  new-dashboard,
-  .dashboard-report__background-image{
+  .dashboard-report__background-image {
     background-color: $main-color;
   }
 }


### PR DESCRIPTION
In the new home, the background image of the exported PDF was not displayed correctly; because there was a background color set in camouflage; on a specific element.

The fix is to set the background _only_ for the element containing the background image.

BEFORE:
[before.pdf](https://github.com/ToucanToco/camouflage/files/3044628/before.pdf)


AFTER:
[after.pdf](https://github.com/ToucanToco/camouflage/files/3044633/after.pdf)
