### PR TITLE
Fix :: Phone edge to edge landscape mode

### DIFF
--- a/variables.scss
+++ b/variables.scss
@@ -66,44 +66,37 @@ $screen-tablet-max: 1024px;
 
 @mixin respond-to($media) {
   @if $media == phone {
-    @media screen and (max-width: $screen-phone-max),
-      projection and (max-width: $screen-phone-max) {
+    @media screen and (max-width: $screen-phone-max), screen and (max-height: $screen-phone-max) {
       @content;
     }
   }
   @if $media == phone-portrait {
-    @media screen and (max-width: $screen-phone-max) and (orientation: portrait),
-      projection and (max-width: $screen-phone-max) and (orientation: portrait) {
+    @media screen and (max-width: $screen-phone-max) and (orientation: portrait) {
       @content;
     }
   }
   @if $media == phone-landscape {
-    @media screen and (max-width: $screen-phone-max) and (orientation: landscape),
-      projection and (max-width: $screen-phone-max) and (orientation: landscape) {
+    @media screen and (max-width: $screen-phone-max) and (orientation: landscape) {
       @content;
     }
   }
   @else if $media == tablet {
-    @media screen and (min-width: $screen-phone-max+1) and (max-width: $screen-tablet-max),
-      projection and (min-width: $screen-phone-max+1) and (max-width: $screen-tablet-max) {
+    @media screen and (min-width: $screen-phone-max+1) and (max-width: $screen-tablet-max) {
       @content;
     }
   }
   @else if $media == tablet-portrait {
-    @media screen and (min-width: $screen-phone-max+1) and (max-width: $screen-tablet-max) and (orientation: portrait),
-      projection and (min-width: $screen-phone-max+1) and (max-width: $screen-tablet-max) and (orientation: portrait) {
+    @media screen and (min-width: $screen-phone-max+1) and (max-width: $screen-tablet-max) and (orientation: portrait) {
       @content;
     }
   }
   @else if $media == tablet-landscape {
-    @media screen and (min-width: $screen-phone-max+1) and (max-width: $screen-tablet-max) and (orientation: landscape),
-      projection and (min-width: $screen-phone-max+1) and (max-width: $screen-tablet-max) and (orientation: landscape) {
+    @media screen and (min-width: $screen-phone-max+1) and (max-width: $screen-tablet-max) and (orientation: landscape) {
       @content;
     }
   }
   @else if $media == desktop {
-    @media screen and (min-width: $screen-tablet-max+1),
-    projection and (min-width: $screen-tablet-max+1){
+    @media screen and (min-width: $screen-tablet-max+1) {
       @content;
     }
   }


### PR DESCRIPTION
Because we have now bigger and edge to edge screen phones, it seems that we have to increase max-with to get the right display (our landscape mode) on these phones too.

The trick is too specify that it doesn't have to exceed the width max also on height, so when it's in landscape it's also handled