### PR TITLE
Fix :: Report selector background color

### DIFF
--- a/views/report-selector.scss
+++ b/views/report-selector.scss
@@ -1,8 +1,6 @@
 report-selector {
   .report-selector-wrapper {
-    $report-selector-main-color-overlay: transparentize($report-selector-main-color, $report-selector-overlay-alpha);
-    $report-selector-bg-overlay: linear-gradient(to bottom, $report-selector-main-color-overlay, $report-selector-main-color-overlay);
-    background-color: $report-selector-bg-overlay;
+    background-color: transparentize($report-selector-main-color, $report-selector-overlay-alpha);
 
     .input-report-wrapper {
       $report-selector-input-color: $report-selector-text-color;


### PR DESCRIPTION
## Description
1. `linear-gradient` only works on `background-image`, not `background-color`
2. The gradient was using only one color, so there was no use for it

Fun fact: It's been broken since june 2016