### PR TITLE
Fix :: Side-panel filters buttons

### DIFF
--- a/new-charts/components/buttons-filter.scss
+++ b/new-charts/components/buttons-filter.scss
@@ -40,3 +40,20 @@
     }
   }
 }
+
+// Customization inside side panel
+.side-panel .tc-controller-buttons.tc-controller-buttons--flat {
+
+  .tc-controller-buttons__button {
+    background-color: transparent;
+    border-color: white;
+    border-left: 1px solid white;
+    color: white;
+  }
+
+  .tc-controller-buttons__button.active {
+    background-color: white;
+    border-color: white;
+    color: $controllerColor;
+  }
+}


### PR DESCRIPTION
The design just not exist, so it looks like buggy

See https://github.com/ToucanToco/tucana/pull/4775

### Before:
Desktop:
<img width="399" alt="Capture d’écran 2019-06-05 à 15 08 00" src="https://user-images.githubusercontent.com/18734475/58959434-6841b100-87a5-11e9-9cf0-b500c56c380d.png">

Desktop hidden buttons:
<img width="396" alt="Capture d’écran 2019-06-05 à 15 08 37" src="https://user-images.githubusercontent.com/18734475/58959435-68da4780-87a5-11e9-94cb-56befd01acd7.png">

Mobile:
<img width="279" alt="Capture d’écran 2019-06-05 à 15 12 14" src="https://user-images.githubusercontent.com/18734475/58959436-6972de00-87a5-11e9-85f5-cdd7cbc79b7c.png">

### After:
Destop:
<img width="398" alt="Capture d’écran 2019-06-05 à 15 13 57" src="https://user-images.githubusercontent.com/18734475/58959502-87d8d980-87a5-11e9-97f4-c00c9d57da77.png">

Mobile: 
<img width="281" alt="Capture d’écran 2019-06-05 à 15 13 14" src="https://user-images.githubusercontent.com/18734475/58959511-8dceba80-87a5-11e9-8cb6-7c8a6da0c88b.png">
