### PR TITLE
Fix specificity of legacy charts colors override with mixin @colorChartsElementsByName

### DIFF
--- a/new-charts/color-elements.scss
+++ b/new-charts/color-elements.scss
@@ -1,9 +1,11 @@
 @mixin colorChartsElementsByName($name, $color) {
   // Legacy
-  [data-subgroup="#{$name}"],
-  [data-label="#{$name}"],
-  [data-serie="#{$name}"] {
-    @include colorSVGElement($color);
+  tc-chart {
+    [data-subgroup="#{$name}"],
+    [data-label="#{$name}"],
+    [data-serie="#{$name}"] {
+      @include colorSVGElement($color);
+    }
   }
 
   // tc-barchart


### PR DESCRIPTION
The specifier for legacy charts was more specific than the one set with the mixin:
![Screenshot from 2019-06-19 16-37-00](https://user-images.githubusercontent.com/932583/59775531-acf33f00-92b1-11e9-9c07-238e6e202aa7.png)
is more specific than
![Screenshot from 2019-06-19 16-36-50](https://user-images.githubusercontent.com/932583/59775547-b2508980-92b1-11e9-921f-23eea2601df5.png)

Fixed it by adding the `.tc-chart` specifier to the scss code produced for legacy charts by the mixin. 