### PR TITLE
Hotfix :: Use neutral, verypositive, verynegative colors

### DIFF
--- a/small-app/home/tiles/tile-score-card.scss
+++ b/small-app/home/tiles/tile-score-card.scss
@@ -12,3 +12,18 @@
 .tile-score-card__value--warning {
   color: $warning-color;
 }
+
+.tile-score-card__variation__icon--neutral,
+.tile-score-card__value--neutral {
+  color: $neutral-color;
+}
+
+.tile-score-card__variation__icon--verypositive,
+.tile-score-card__value--verypositive {
+  color: $verypositive-color;
+}
+
+.tile-score-card__variation__icon--verynegative,
+.tile-score-card__value--verynegative {
+  color: $verynegative-color;
+}

--- a/small-app/home/tiles/tile-value.scss
+++ b/small-app/home/tiles/tile-value.scss
@@ -9,3 +9,15 @@
 .tile-value__content--warning {
   color: $warning-color;
 }
+
+.tile-value__content--neutral {
+  color: $neutral-color;
+}
+
+.tile-value__content--verypositive {
+  color: $verypositive-color;
+}
+
+.tile-value__content--verynegative {
+  color: $verynegative-color;
+}


### PR DESCRIPTION
We were not using the full sentiment palette

before :
<img width="514" alt="Screen Shot 2019-07-23 at 14 49 48" src="https://user-images.githubusercontent.com/7557261/61713539-2373d880-ad59-11e9-8b64-e3410f4cec03.png">


after
<img width="1066" alt="Screen Shot 2019-07-23 at 14 48 43" src="https://user-images.githubusercontent.com/7557261/61713516-15be5300-ad59-11e9-9114-e3a235c01021.png">
