### PR TITLE
Fix :: legacy color mixin

### DIFF
--- a/new-charts/color-elements.scss
+++ b/new-charts/color-elements.scss
@@ -1,6 +1,6 @@
 @mixin colorChartsElementsByName($name, $color) {
   // Legacy
-  tc-chart {
+  barlinechart, bubblechart, bullet-chart, carto, filtrable-waterfall-chart, force-directed-chartlinechart, heatmap, horizontal-barchart, leaderboard-centered-average, score-card, slopegraph, stacked-barchart, tc-treemap, text-slide, verbatim, waterfall-chart {
     [data-subgroup="#{$name}"],
     [data-label="#{$name}"],
     [data-serie="#{$name}"] {


### PR DESCRIPTION
This fix fix this fix ( 😎) => https://github.com/ToucanToco/camouflage/pull/224

I use all the legacy directive names instead of `tc-chart` because it not include all the legacy charts (ex: linechart)