### PR TITLE
Charts :: Fix series colors mixin

### DIFF
--- a/new-charts/color-elements.scss
+++ b/new-charts/color-elements.scss
@@ -20,6 +20,9 @@
   // tc-lines
   @include colorTcLinesSerieByName($name, $color);
 
+  // tc-linechart v2
+  @include colorTcLinechartSerieByName($name, $color);
+
   // tc-bubblechart
   @include colorBubbleChartByName($name, $color);
 
@@ -28,6 +31,7 @@
 
   // tc-radarchart
   @include colorTcRadarchartShapeByName($name, $color);
+  @include colorTcRadarchartMetricsLabelByName($name, $color);
 
   // tc-stackedbarchart
   @include colorStackedBarsByName($name, $color);

--- a/new-charts/tc-linechart.scss
+++ b/new-charts/tc-linechart.scss
@@ -7,6 +7,10 @@
 @mixin colorLinesById($id, $color) {
     @include colorLinesByAttr(data-serie-index, $id, $color);
 }
+
+@mixin colorTcLinechartSerieByName($name, $color) {
+  @include colorLinesByAttr(data-serie, $name, $color);
+}
   
 @each $color in $chartColors {
     $i: index($chartColors, $color) - 1;


### PR DESCRIPTION
Series colors mixin was not fully integrated to some charts.
We needed to add label color for radarchart and a new mixin for line chart v2.

These PR is linked to tucana : [https://github.com/ToucanToco/tucana/pull/6311](https://github.com/ToucanToco/tucana/pull/6311)

## Related Screenshots

### LineChart
**Before**
![linechart-before](https://user-images.githubusercontent.com/59559689/76401216-d6915080-6381-11ea-9c4d-cf62c2381a03.png)
**After**
![linechart-after](https://user-images.githubusercontent.com/59559689/76401227-db560480-6381-11ea-9c5c-2fa5f15b4d62.png)

### RadarChart
**Before**
![radar-before](https://user-images.githubusercontent.com/59559689/76401174-c8433480-6381-11ea-8981-555ed34e9e23.png)
**After**
![radarchart-after](https://user-images.githubusercontent.com/59559689/76401185-cbd6bb80-6381-11ea-8a2f-32af46e2e0e6.png)
