### PR TITLE
Linechart (old) :: Give a higher priority to the data-serie rules

### DIFF
--- a/new-charts/color-elements.scss
+++ b/new-charts/color-elements.scss
@@ -1,6 +1,22 @@
 @mixin colorChartsElementsByName($name, $color) {
   // Legacy
-  barlinechart, bubblechart, bullet-chart, carto, filtrable-waterfall-chart, force-directed-chartlinechart, heatmap, horizontal-barchart, leaderboard-centered-average, linechart, score-card, slopegraph, stacked-barchart, tc-treemap, text-slide, verbatim, waterfall-chart {
+  barlinechart, 
+  bubblechart, 
+  bullet-chart, 
+  carto, 
+  filtrable-waterfall-chart, 
+  force-directed-chartlinechart, 
+  heatmap, 
+  horizontal-barchart, 
+  leaderboard-centered-average, 
+  linechart .chart-container, // Give a higher priority to this rule than data-serie-index 
+  score-card, 
+  slopegraph, 
+  stacked-barchart, 
+  tc-treemap, 
+  text-slide, 
+  verbatim, 
+  waterfall-chart {
     [data-subgroup="#{$name}"],
     [data-label="#{$name}"],
     [data-serie="#{$name}"] {


### PR DESCRIPTION
For the linechart legacy, we want data-serie rules to be prioritized over data-serie-index
This was not the case because of the order of the scss imports
I added a class to the linechart rule so that data-serie has a higher priority