### PR TITLE
Fix :: Set input type range background based on custom smallApp variables

### DIFF
--- a/new-charts/components/slider-filter.scss
+++ b/new-charts/components/slider-filter.scss
@@ -10,14 +10,8 @@
   color: $controllerColor;
 }
 
-.tc-slider-vue__input::-webkit-slider-runnable-track {
-  background: $controllerColor;
-}
-
-.tc-slider-vue__input::-moz-range-track {
-  background: $controllerColor;
-}
-
+.tc-slider-vue__input::-webkit-slider-runnable-track,
+.tc-slider-vue__input::-moz-range-track,
 .tc-slider-vue__input::-ms-fill-lower,
 .tc-slider-vue__input::-ms-fill-upper {
   background: $controllerColor;

--- a/new-charts/components/slider-filter.scss
+++ b/new-charts/components/slider-filter.scss
@@ -17,3 +17,8 @@
 .tc-slider-vue__input::-moz-range-track {
   background: $controllerColor;
 }
+
+.tc-slider-vue__input::-ms-fill-lower,
+.tc-slider-vue__input::-ms-fill-upper {
+  background: $controllerColor;
+}

--- a/new-charts/components/slider-filter.scss
+++ b/new-charts/components/slider-filter.scss
@@ -13,3 +13,7 @@
 .tc-slider-vue__input::-webkit-slider-runnable-track {
   background: $controllerColor;
 }
+
+.tc-slider-vue__input::-moz-range-track {
+  background: $controllerColor;
+}


### PR DESCRIPTION
Move css from tucana to camouflage to get custom colors variables applied to input type range background.

Needed to remove code in tucana : https://github.com/ToucanToco/tucana/pull/6379