### PR TITLE
Chart Colors :: Fix index off by one error

### DIFF
--- a/charts/bullet-chart.scss
+++ b/charts/bullet-chart.scss
@@ -1,7 +1,7 @@
 bullet-chart {
-  $barColor: map-get($chartColors,1);
-  $comparisonColor: map-get($chartColors,2);
-  $targetColor: map-get($chartColors,3);
+  $barColor: map-get($chartColors,0);
+  $comparisonColor: map-get($chartColors,1);
+  $targetColor: map-get($chartColors,2);
 
   .bar rect, rect.bar {
     fill: $barColor;

--- a/dashboard-report.scss
+++ b/dashboard-report.scss
@@ -91,10 +91,10 @@
         .widget-type-leaderboard {
           .widget-chart-container {
             .bar:not(.sentiment-zones) {
-                fill: map-get($chartColors,1);
+                fill: map-get($chartColors,0);
               }
             .target:not(.sentiment-zones) {
-                fill: map-get($chartColors,3);
+                fill: map-get($chartColors,2);
               }
           }
           .horizontal-barchart-subgroup.horizontal-barchart-subgroup--highlighted .bar-label {

--- a/new-charts/graphical-elements/bullet.scss
+++ b/new-charts/graphical-elements/bullet.scss
@@ -1,3 +1,3 @@
 .tc-bullet{
-  fill: map-get($chartColors, 3);
+  fill: map-get($chartColors, 2);
 }

--- a/new-charts/graphical-elements/horizontal-bar-with-bullet.scss
+++ b/new-charts/graphical-elements/horizontal-bar-with-bullet.scss
@@ -1,5 +1,5 @@
 .tc-horizontal-bar-with-bullet__bar{
-  fill: map-get($chartColors, 1);
+  fill: map-get($chartColors, 0);
 }
 
 .tc-horizontal-bar-with-bullet__comparison{

--- a/sparklines.scss
+++ b/sparklines.scss
@@ -13,7 +13,7 @@
 }
 .widget-sparkline-container {
   .line {
-    stroke: map-get($chartColors,1);
+    stroke: map-get($chartColors,0);
   }
 
   .sparkline-selected {

--- a/variables.scss
+++ b/variables.scss
@@ -330,8 +330,8 @@ $new-small-app-primary-color:                 $main-color-dark !default;
 
 // CHARTS
 // BAR/BARLINE
-$barColor:                                    map-get($chartColors,3);
-$lineColor:                                   map-get($chartColors,1);
+$barColor:                                    map-get($chartColors,2);
+$lineColor:                                   map-get($chartColors,0);
 // BULLETCHART
 $bullet-chart-detail-block-bg:                #f0f0f0 !default;
 $bullet-chart-axis-color:                     #f5f5f5 !default;


### PR DESCRIPTION
In https://github.com/ToucanToco/camouflage/pull/272/files we introduced a new way to have chart color arrays
When using map-get, we start at `0`, where we used to start at `1` for iterating through arrays.

I'm offsetting the index so this doesnt change the colors on charts (bullets in particular)

before
![Screen Shot 2020-04-10 at 11 08 59](https://user-images.githubusercontent.com/7557261/78979235-b937d980-7b1b-11ea-895f-5129900b7df7.png)
after
![Screen Shot 2020-04-10 at 11 07 15](https://user-images.githubusercontent.com/7557261/78979226-b50bbc00-7b1b-11ea-826d-72a2386f3db7.png)
