### PR TITLE
TableChart :: Add mixin to custom colors with color scheme interface

### DIFF
--- a/new-charts/color-elements.scss
+++ b/new-charts/color-elements.scss
@@ -49,6 +49,9 @@
 
   // tc-stackedbarchart
   @include colorStackedBarsByName($name, $color);
+
+  // tc-tablechart
+  @include colorTcTableByName($name, $color);
 }
 
 @each $serieLabel, $serieColor in $tc-series-colors {

--- a/new-charts/tc-tablechart.scss
+++ b/new-charts/tc-tablechart.scss
@@ -64,6 +64,10 @@ $closeIconColor: #D4D4D4;
   @include colorTcTableByAttr(data-serie-index, $id, $color);
 }
 
+@mixin colorTcTableByName($name, $color) {
+  @include colorTcTableByAttr(data-serie-label, $name, $color);
+}
+
 @each $i, $color in $chartColors {
   @include colorTcTableById($i, $color);
 }


### PR DESCRIPTION
* Add new mixin colorTcTableByName
* Call mixin in colorChartsElementsByName to link tcSeriesCustomColors.

It will now be possible to set custom colors to TableChart from color scheme interface

:information_source: Has been verified locally!