### PR TITLE
Tutorial :: fix var name

### DIFF
--- a/small-app-tutorial.scss
+++ b/small-app-tutorial.scss
@@ -8,7 +8,7 @@
   }
 }
 .small-app-tutorial__bullet {
-  background-color: $grey-light-1;
+  background-color: $tc-color--grey-light-1;
   &.small-app-tutorial__bullet--active {
     background-color: $main-color;
   }


### PR DESCRIPTION
The styles couldnt compile in laputa


```
Error
sass.CompileError: b'Error: Undefined variable: "$grey-light-1".\n        on line 11 of bower_components/tc-camouflage/small-app-tutorial.scss\n>>   background-color: $grey-light-1;\n   --------------------^\n'
Stacktrace
small_app = laputa
    def test_get_styles(small_app):
        """It should provide the stylesheet compiled with the small app variables"""
>       small_app.save_styles_variables({'variables': {'emphasis-color': 'purple'}})
tests/app/test_small_app.py:529: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
laputa/app/small_app.py:1913: in save_styles_variables
    self.compile_styles(new_styles_variables)
laputa/app/small_app.py:1989: in compile_styles
    output_style='compressed',
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
```