### PR TITLE
Bullet :: Allow custom colors series

### DIFF
--- a/new-charts/color-elements.scss
+++ b/new-charts/color-elements.scss
@@ -50,6 +50,9 @@
 
   // tc-tablechart
   @include colorTcTableByName($name, $color);
+
+  //tc-bullet-chart
+  @include colorBulletChartSerieByName($name, $color);
 }
 
 @each $serieLabel, $serieColor in $tc-series-colors {

--- a/new-charts/tc-bullet-chart.scss
+++ b/new-charts/tc-bullet-chart.scss
@@ -34,3 +34,21 @@
   @include bullet-chart__serie($sentiment, $color, sentiment);
 }
 @include bullet-chart__serie(value, $tc-color--serie-2);
+
+@mixin colorBulletAttrByName($attr, $serie, $color, $el: $serie) {
+  .bullet-chart__bullet[data-#{$attr}='#{$serie}'] .bullet__#{$attr},
+  .bullet-chart__details .serie[data-type="#{$attr}"][data-label='#{$serie}'] .serie__color {
+    background-color: $color;
+  }
+  // el is needed because in tile we have no consistancy between classes and params
+  // TODO: refacto tile bullet to have similar behaviour than in bullet chart
+  .tc-horizontal-bar-with-bullet[data-#{$attr}='#{$serie}'] .tc-horizontal-bar-with-bullet__#{$el} {
+    fill: $color;
+  }
+}
+
+@mixin colorBulletChartSerieByName($serie, $color) {
+  @include colorBulletAttrByName(comparison, $serie, $color, comparison);
+  @include colorBulletAttrByName(target, $serie, $color, bullet);
+  @include colorBulletAttrByName(value, $serie, $color, bar);
+}

--- a/new-charts/tc-bullet-chart.scss
+++ b/new-charts/tc-bullet-chart.scss
@@ -30,8 +30,6 @@
 @each $name, $color in $tc-bullet-default-colors {
   @include colorBulletLegendByName($name, $color);
   @include colorBulletPart($color, $name);
-  @include colorBulletPart($color, $name);
-  @include colorBulletPart($color, $name);
 }
 
 // Sentiments

--- a/new-charts/tc-bullet-chart.scss
+++ b/new-charts/tc-bullet-chart.scss
@@ -1,73 +1,51 @@
-// Tile
-.tc-horizontal-bar-with-bullet__comparison {
-  fill: $bullet-comparison-color;
-}
-.tc-horizontal-bar-with-bullet__bar {
-  fill: $bullet-value-color;
-}
-.tc-horizontal-bar-with-bullet__bullet {
-  fill: $bullet-target-color;
-}
-
-// TcBullet
-.bullet__comparison {
-  background-color: $bullet-comparison-color;
-}
-
-.bullet__target {
-  background-color: $bullet-target-color;
-}
-
-@each $sentiment, $color in $tc-color__sentiments {
-  .bullet__target[data-sentiment='#{$sentiment}'] {
-    background-color: $color;
-  }
-}
-
-.bullet__value {
-  background-color: $bullet-value-color;
-}
-
-.bullet__value-container {
-  background-color: $tc-color--grey-extralight-1;
-}
-
-// Series
-@mixin bullet-chart__serie($serie, $color, $attribute: 'type') {
+// Legend
+@mixin colorBulletLegendByName($serie, $color, $attribute: 'type') {
+  .tc-legend-ordinal__serie[data-style='#{$serie}'] .tc-legend-ordinal__serie-color,
   .bullet-chart__details .serie[data-#{$attribute}='#{$serie}'] .serie__color {
     background-color: $color;
   }
-  @include colorTileBulletChartPartBySerie($serie, $color);
 }
 
-@mixin colorTileBulletChartPartBySerie($serie, $color) {
-  .tc-legend-ordinal__serie[data-style='#{$serie}'] .tc-legend-ordinal__serie-color {
-    background-color: $color;
-  }
-}
-
-@include bullet-chart__serie(comparison, $bullet-comparison-color);
-@include bullet-chart__serie(target, $bullet-target-color);
-@include bullet-chart__serie(value, $bullet-value-color);
-
-@each $sentiment, $color in $tc-color__sentiments {
-  @include bullet-chart__serie($sentiment, $color, sentiment);
-}
-
-@mixin colorBulletAttrByName($attr, $serie, $color, $el: $serie) {
-  .bullet-chart__bullet[data-#{$attr}='#{$serie}'] .bullet__#{$attr},
-  .bullet-chart__details .serie[data-type="#{$attr}"][data-label='#{$serie}'] .serie__color {
-    background-color: $color;
-  }
-  // el is needed because in tile we have no consistancy between classes and params
-  // TODO: refacto tile bullet to have similar behaviour than in bullet chart
-  .tc-horizontal-bar-with-bullet[data-#{$attr}='#{$serie}'] .tc-horizontal-bar-with-bullet__#{$el} {
+@mixin colorBulletPart($color, $part: comparison) {
+  .tc-horizontal-bar-with-bullet__#{$part} {
     fill: $color;
   }
+  .bullet__#{$part} {
+    background-color: $color;
+  }
 }
 
+@mixin colorBulletPartByAttr($serie, $color, $part, $attr: serie) {
+  .tc-horizontal-bar-with-bullet__#{$part}[data-#{$attr}='#{$serie}'] {
+    fill: $color;
+  }
+  .bullet__#{$part}[data-#{$attr}='#{$serie}'] {
+    background-color: $color;
+  }
+}
+
+/****** APPLY COLORS ******/
+
+// Default
+@each $name, $color in $tc-bullet-default-colors {
+  @include colorBulletLegendByName($name, $color);
+  @include colorBulletPart($color, $name);
+  @include colorBulletPart($color, $name);
+  @include colorBulletPart($color, $name);
+}
+
+// Sentiments
+@each $sentiment, $color in $tc-color__sentiments {
+  @include colorBulletLegendByName($sentiment, $color, sentiment);
+  @include colorBulletPartByAttr($sentiment, $color, target, sentiment);
+}
+
+/****** SERIES ******/
+
+// Custom colors
 @mixin colorBulletChartSerieByName($serie, $color) {
-  @include colorBulletAttrByName(comparison, $serie, $color, comparison);
-  @include colorBulletAttrByName(target, $serie, $color, bullet);
-  @include colorBulletAttrByName(value, $serie, $color, bar);
+  @include colorBulletPartByAttr($serie, $color, value);
+  @include colorBulletPartByAttr($serie, $color, target);
+  @include colorBulletPartByAttr($serie, $color, comparison);
+  @include colorBulletLegendByName($serie, $color, label);
 }

--- a/variables.scss
+++ b/variables.scss
@@ -350,9 +350,12 @@ $tc-bar-selector-stroke: 		      #D8D8D8 !default;
 $funnelchart-bar-color: map-get($chartColors,1);
 
 //BULLETCHART
-$bullet-comparison-color:  mix($chart-color-2, white, 33%);
-$bullet-value-color: $chart-color-2;
-$bullet-target-color: $chart-color-1;
+$bullet-comparison-color: mix($chart-color-2, white, 33%);
+$tc-bullet-default-colors: (
+  comparison: $bullet-comparison-color,
+  target: $chart-color-1,
+  value: $chart-color-2,
+);
 
 /*** SLIDES ***/
 // RECOMMENDATION


### PR DESCRIPTION
Before: we was'nt able to use custom colors in bullet chart so it was confusing for conceptors (legend was already custom colored).
After: Custom colors can be used in bullet chart.

:link: :sos: Tucana : https://github.com/ToucanToco/tucana/pull/6691
:clock1: Laputa Bump : :construction: 

:new:
* Add a new mixin to call with custom colors
* These mixin iterate through attrs ( data-comparison, data-target, data-value, with serie as value ). So the name of the column will be used to color the different part of the charts

- [ ] Need https://github.com/ToucanToco/tucana/pull/6689, to be review