### PR TITLE
feat(design): change color of source/comment to a more visible one

### DIFF
--- a/variables.scss
+++ b/variables.scss
@@ -259,7 +259,7 @@ $greyDark: #d9d9d9;
 $backgroundSlideCommentary: $greyLight;
 
 $text-color: #4c4c4c !default;
-$faded-text: #b4b4b4;
+$faded-text: #737373;
 
 $dropAreaTextColor: #b7d1cb;
 $backgroundDropAreaColor: #f5faf9;


### PR DESCRIPTION
## Description
Change the color of source and comment text to make it more visible to users

## Impact of the PR
/

### On-Premise specific
/

## Related PRs/Screenshots/Additional info
<img width="352" alt="Capture d’écran 2020-10-28 à 14 08 06" src="https://user-images.githubusercontent.com/28353442/97439895-0e580300-1927-11eb-8662-eb66f6ac9982.png">
<img width="352" alt="Capture d’écran 2020-10-28 à 14 07 44" src="https://user-images.githubusercontent.com/28353442/97439890-0bf5a900-1927-11eb-92f4-818f2bffd329.png">

