### PR TITLE
fix; bulletchart value color serie

### DIFF
--- a/variables.scss
+++ b/variables.scss
@@ -341,11 +341,11 @@ $tc-bar-selector-stroke: 		      #D8D8D8 !default;
 $funnelchart-bar-color: map-get($chartColors,1);
 
 //BULLETCHART
-$bullet-comparison-color: mix($chart-color-2, white, 33%);
+$bullet-comparison-color: mix($chart-color-0, white, 33%);
 $tc-bullet-default-colors: (
   comparison: $bullet-comparison-color,
+  value: $chart-color-0,
   target: $chart-color-1,
-  value: $chart-color-2,
 );
 
 /*** SLIDES ***/


### PR DESCRIPTION
Color of the value of the bulletchart was serie 3 while we wanted serie 1.
Fixed that for you !

It was kinda hard to test locally but it should work. Not 100% sure because my test made funky results but it should be all ok !

I will do further tests after this is merged, and before merging the version bump on tucana and laputa