### PR TITLE
fix(bulletchart): sentiment legend colors

### DIFF
--- a/new-charts/tc-bullet-chart.scss
+++ b/new-charts/tc-bullet-chart.scss
@@ -1,10 +1,21 @@
 // Legend
-@mixin colorBulletLegendByName($serie, $color, $attribute: 'type') {
-  .tc-legend-ordinal__serie[data-style="#{$serie}"] .tc-legend-ordinal__serie-color,
+@mixin colorBulletTileLegendByName($serie, $color, $attribute) {
+  .tc-legend-ordinal__serie[data-#{$attribute}="#{$serie}"] .tc-legend-ordinal__serie-color {
+    background-color: $color;
+  }
+}
+
+@mixin colorBulletChartLegendByName($serie, $color, $attribute) {
   .bullet-chart__details .serie[data-#{$attribute}="#{$serie}"] .serie__color {
     background-color: $color;
   }
 }
+
+@mixin colorBulletLegendByName($serie, $color, $attribute) {
+  @include colorBulletTileLegendByName($serie, $color, $attribute);
+  @include colorBulletChartLegendByName($serie, $color, $attribute);
+}
+
 
 @mixin colorBulletPart($color, $part: comparison) {
   .tc-horizontal-bar-with-bullet__#{$part} {
@@ -28,7 +39,8 @@
 
 // Default
 @each $name, $color in $tc-bullet-default-colors {
-  @include colorBulletLegendByName($name, $color);
+  @include colorBulletTileLegendByName($name, $color, style);
+  @include colorBulletChartLegendByName($name, $color, type);
   @include colorBulletPart($color, $name);
 }
 


### PR DESCRIPTION
## Description 

In TcLegendOrdinal, we use `.tc-legend-ordinal__serie[data-sentiment="#{$sentiment}"] .tc-legend-ordinal__serie-color` to override the color by the sentiment color. 

However in the bulletchart, we were using `.tc-legend-ordinal__serie-color[data-style="#{$sentiment}"] .tc-legend-ordinal__serie-color` (and not data-sentiment) which is not used in TcLegendOrdinal. That is why the sentiment color was not applied. 

In the example below, a sentiment is applied on the value.

## Before 
![image](https://user-images.githubusercontent.com/28828162/112203104-737ffe00-8c12-11eb-88eb-e5078e84a092.png)

## After
![image](https://user-images.githubusercontent.com/28828162/112203034-5cd9a700-8c12-11eb-8055-ee54e273de25.png)
