### PR TITLE
fix(bubblechart): add default legend color corresponding to the bubbl…

### DIFF
--- a/new-charts/tc-bubblechart.scss
+++ b/new-charts/tc-bubblechart.scss
@@ -68,6 +68,11 @@ circle.bubblechart__bubbles__main__drill-circle {
   box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.3);
 }
 
+.bubblechart__legend .metric__color__rect {
+    background-color: $neutralColor;
+  
+}
+
 // BUBBLE LABELS
 text.bubblechart__label{
   &.highlighted {
@@ -85,7 +90,7 @@ text.bubblechart__label{
   circle.bubblechart__bubbles[#{$attr}="#{$value}"] {
     fill: $color;
   }
-  .bubblechart__legend {
+  .bubblechart__legend {  
     .metric__color__rect[#{$attr}="#{$value}"],
     .tc-legend-ordinal__serie[#{$attr}="#{$value}"] .tc-legend-ordinal__serie-color {
       background-color: $color;
@@ -116,6 +121,7 @@ text.bubblechart__label{
   @include colorBubblesByAttr(data-group, $name, $color);
   @include colorBubblesByAttr(data-style, $name, $color);
 }
+
 
 // LEGEND
 @each $sentiment, $color in $sentiment-colors {


### PR DESCRIPTION
…e color

Same color as the bubble's default color https://github.com/ToucanToco/camouflage/blob/7594a36b1a2b8d55e65b2c7b23943f311ddd7416/new-charts/tc-bubblechart.scss#L18

![image](https://user-images.githubusercontent.com/28828162/112210096-8eef0700-8c1a-11eb-848d-126a978c9740.png)
